### PR TITLE
use the public hostname for the kojifiles store

### DIFF
--- a/components/koji_hub/configmap.yml
+++ b/components/koji_hub/configmap.yml
@@ -118,8 +118,8 @@ data:
   kojiweb.conf: |-
     [web]
     SiteName = MBOX Koji
-    KojiHubURL = https://localhost:8443/kojihub
-    KojiFilesURL = https://koji-hub:8443/pkgs
+    KojiHubURL = https://koji-hub:8443/kojihub
+    KojiFilesURL = https://{{ public_hostname }}/pkgs
     Secret = MboxKojiWeb
     LibPath = /usr/share/koji-web/lib
     LoginDisabled = True


### PR DESCRIPTION
kojiweb uses that to spit out links to the console logs client-side, so
we need the urls to point at the route, rather than the internal
openshift service